### PR TITLE
fix: Use Terraform output for ECR repository name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,13 @@ jobs:
         run: terraform apply -var-file="feature.tfvars" -auto-approve
         working-directory: terraform/environments/feature
 
+      - name: Get ECR Repository URL
+        id: ecr-url
+        run: |
+          ecr_repo_url=$(terraform output -raw ecr_repository_url)
+          echo "ecr_repo_url=$ecr_repo_url" >> $GITHUB_OUTPUT
+        working-directory: terraform/environments/feature
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
@@ -107,13 +114,12 @@ jobs:
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+          ECR_REPOSITORY_URL: ${{ steps.ecr-url.outputs.ecr_repo_url }}
           IMAGE_TAG: ${{ github.sha }}
         run: |
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          echo "::set-output name=image::$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+          docker build -t $ECR_REPOSITORY_URL:$IMAGE_TAG .
+          docker push $ECR_REPOSITORY_URL:$IMAGE_TAG
+          echo "::set-output name=image::$ECR_REPOSITORY_URL:$IMAGE_TAG"
 
       - name: Scan image with Trivy
         uses: aquasecurity/trivy-action@master

--- a/terraform/environments/feature/outputs.tf
+++ b/terraform/environments/feature/outputs.tf
@@ -1,0 +1,4 @@
+output "ecr_repository_url" {
+  description = "The URL of the ECR repository"
+  value       = module.ecr.repository_url
+}


### PR DESCRIPTION
This commit fixes a bug where the Docker push step was failing because it was using a different ECR repository name than the one created by Terraform.

The workflow now gets the ECR repository URL from the Terraform output and uses it in the Docker build and push steps. This ensures that the correct repository is used and removes the need for the `ECR_REPOSITORY` secret.