### PR TITLE
fix: Declare enable_nat_gateway variable

### DIFF
--- a/terraform/environments/feature/variables.tf
+++ b/terraform/environments/feature/variables.tf
@@ -32,6 +32,12 @@ variable "public_subnets" {
   type        = list(string)
 }
 
+variable "enable_nat_gateway" {
+  description = "Controls if NAT Gateways are created in the VPC"
+  type        = bool
+  default     = true
+}
+
 variable "cluster_name" {
   description = "Name of the EKS cluster"
   type        = string


### PR DESCRIPTION
This commit fixes the root cause of the pipeline failures by declaring the `enable_nat_gateway` variable in the feature environment's `variables.tf` file.

This allows the `enable_nat_gateway = false` setting in the `.tfvars` file to be correctly applied, preventing the `AddressLimitExceeded` error that was causing the `terraform apply` to fail and the state to become inconsistent.