### PR TITLE
refactor: Simplify EKS module to remove complex dependencies

### DIFF
--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -1,29 +1,88 @@
 # terraform/modules/eks/main.tf
 
-module "eks" {
-  source  = "terraform-aws-modules/eks/aws"
-  version = "19.15.3"
+# IAM Role for EKS Cluster
+resource "aws_iam_role" "cluster" {
+  name = "${var.cluster_name}-cluster"
 
-  create_kms_key = var.create_kms_key
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "eks.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
 
-  cluster_name    = var.cluster_name
-  cluster_version = var.cluster_version
+resource "aws_iam_role_policy_attachment" "cluster_AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster.name
+}
 
-  vpc_id     = var.vpc_id
-  subnet_ids = var.subnet_ids
+# IAM Role for EKS Nodes
+resource "aws_iam_role" "nodes" {
+  name = "${var.cluster_name}-nodes"
 
-  eks_managed_node_groups = {
-    one = {
-      name           = "node-group-1"
-      instance_types = var.instance_types
-      min_size     = var.min_size
-      max_size     = var.max_size
-      desired_size = var.desired_size
-    }
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "nodes_AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.nodes.name
+}
+
+resource "aws_iam_role_policy_attachment" "nodes_AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.nodes.name
+}
+
+# EKS Cluster
+resource "aws_eks_cluster" "this" {
+  name     = var.cluster_name
+  version  = var.cluster_version
+  role_arn = aws_iam_role.cluster.arn
+
+  vpc_config {
+    subnet_ids = var.subnet_ids
   }
 
-  tags = {
-    Terraform   = "true"
-    Environment = "dev"
+  depends_on = [
+    aws_iam_role_policy_attachment.cluster_AmazonEKSClusterPolicy,
+  ]
+}
+
+# EKS Node Group
+resource "aws_eks_node_group" "this" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_group_name = "${var.cluster_name}-node-group"
+  node_role_arn   = aws_iam_role.nodes.arn
+  subnet_ids      = var.subnet_ids
+
+  scaling_config {
+    desired_size = var.desired_size
+    max_size     = var.max_size
+    min_size     = var.min_size
   }
+
+  instance_types = var.instance_types
+
+  depends_on = [
+    aws_iam_role_policy_attachment.nodes_AmazonEKSWorkerNodePolicy,
+    aws_iam_role_policy_attachment.nodes_AmazonEC2ContainerRegistryReadOnly,
+  ]
 }

--- a/terraform/modules/eks/outputs.tf
+++ b/terraform/modules/eks/outputs.tf
@@ -2,15 +2,10 @@
 
 output "cluster_endpoint" {
   description = "Endpoint for the EKS cluster"
-  value       = module.eks.cluster_endpoint
+  value       = aws_eks_cluster.this.endpoint
 }
 
 output "cluster_name" {
   description = "Name of the EKS cluster"
-  value       = module.eks.cluster_name
-}
-
-output "cluster_oidc_issuer_url" {
-  description = "OIDC issuer URL for the EKS cluster"
-  value       = module.eks.cluster_oidc_issuer_url
+  value       = aws_eks_cluster.this.name
 }

--- a/terraform/modules/eks/variables.tf
+++ b/terraform/modules/eks/variables.tf
@@ -16,7 +16,7 @@ variable "vpc_id" {
 }
 
 variable "subnet_ids" {
-  description = "List of subnet IDs where the cluster will be deployed"
+  description = "List of subnet IDs where the EKS cluster and nodes will be deployed"
   type        = list(string)
 }
 
@@ -38,10 +38,4 @@ variable "max_size" {
 variable "desired_size" {
   description = "Desired number of nodes in the node group"
   type        = number
-}
-
-variable "create_kms_key" {
-  description = "Controls if a KMS key is created for the EKS cluster"
-  type        = bool
-  default     = true
 }


### PR DESCRIPTION
This commit refactors the local EKS module to use simple, direct `aws_eks_cluster` and `aws_eks_node_group` resources instead of the complex public `terraform-aws-modules/eks/aws` module.

This change was made to resolve a series of persistent pipeline errors related to unwanted "helper" resources (like KMS keys and EIPs) and provider version incompatibilities. The new, simpler module gives us direct control over the created resources and removes the problematic dependencies.