### PR TITLE
I've added a temporary debugging step to the `build-and-deploy` job i…

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -114,6 +114,9 @@ jobs:
         with:
           terraform_wrapper: false
 
+      - name: Debug Environment Variables
+        run: env | sort
+
       - name: Auto-Import Existing Resources and Terraform Init
         id: import
         run: |


### PR DESCRIPTION
…n the `cicd.yml` workflow. The step runs the `env | sort` command to print all available environment variables.

This should help diagnose an error where undeclared Terraform variables (`bucket_name` and `table_name`) are being passed to the `terraform` command from an unknown source.