### PR TITLE
fix: Add var-file to import commands and delete old main.yml

### DIFF
--- a/scripts/auto_import.sh
+++ b/scripts/auto_import.sh
@@ -30,7 +30,7 @@ if aws eks describe-cluster --name "$EKS_CLUSTER_NAME" >/dev/null 2>&1; then
   echo "EKS cluster '$EKS_CLUSTER_NAME' exists."
   if ! terraform state list | grep -q 'module.eks.aws_eks_cluster.this'; then
     echo "Importing EKS cluster..."
-    terraform import module.eks.aws_eks_cluster.this "$EKS_CLUSTER_NAME"
+    terraform import -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_eks_cluster.this "$EKS_CLUSTER_NAME"
   else
     echo "EKS cluster already in state."
   fi
@@ -43,7 +43,7 @@ if aws ecr describe-repositories --repository-names "$ECR_REPO_NAME" >/dev/null 
   echo "ECR repository '$ECR_REPO_NAME' exists."
   if ! terraform state list | grep -q 'module.ecr.aws_ecr_repository.app'; then
     echo "Importing ECR repository..."
-    terraform import module.ecr.aws_ecr_repository.app "$ECR_REPO_NAME"
+    terraform import -var-file="${ENVIRONMENT}.tfvars" module.ecr.aws_ecr_repository.app "$ECR_REPO_NAME"
   else
     echo "ECR repository already in state."
   fi
@@ -56,7 +56,7 @@ if aws dynamodb describe-table --table-name "$DYNAMO_TABLE_NAME" >/dev/null 2>&1
   echo "App DynamoDB table '$DYNAMO_TABLE_NAME' exists."
   if ! terraform state list | grep -q 'module.dynamodb.aws_dynamodb_table.app_table'; then
     echo "Importing App DynamoDB table..."
-    terraform import module.dynamodb.aws_dynamodb_table.app_table "$DYNAMO_TABLE_NAME"
+    terraform import -var-file="${ENVIRONMENT}.tfvars" module.dynamodb.aws_dynamodb_table.app_table "$DYNAMO_TABLE_NAME"
   else
     echo "App DynamoDB table already in state."
   fi


### PR DESCRIPTION
I've made two main fixes in this commit:

1.  **Fix Terraform Import:** I found that the `auto_import.sh` script was failing with a 'No value for required variable' error. This was because the `terraform import` commands were not being provided with the necessary variable definitions. I've updated the script to include the `-var-file` flag in all `terraform import` commands, ensuring they have the context they need to run successfully.

2.  **Delete Redundant Workflow:** As you requested, I have deleted the old, monolithic CI/CD workflow file, `.github/workflows/main.yml`. Its functionality has been fully replaced by the new, separated `infrastructure.yml` and `application.yml` workflows.