### PR TITLE
fix(destroy): Implement two-stage destroy for EKS

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -47,7 +47,11 @@ jobs:
             -backend-config="dynamodb_table=my-flask-app-terraform-lock"
         working-directory: terraform/environments/${{ github.event.inputs.environment }}
 
-      - name: Terraform Destroy
+      - name: Terraform Destroy Node Group
+        run: terraform destroy -target=module.eks.aws_eks_node_group.this -var-file="${{ github.event.inputs.environment }}.tfvars" -auto-approve
+        working-directory: terraform/environments/${{ github.event.inputs.environment }}
+
+      - name: Terraform Destroy Remaining Resources
         run: terraform destroy -var-file="${{ github.event.inputs.environment }}.tfvars" -auto-approve
         working-directory: terraform/environments/${{ github.event.inputs.environment }}
 


### PR DESCRIPTION
This commit fixes a 'ResourceInUseException' error that occurred when destroying the EKS cluster. The error happened because Terraform attempted to delete the cluster before the associated node group was fully terminated.

The `destroy.yml` workflow has been updated to handle this gracefully. The `destroy-environment` job now performs a two-stage destroy:

1.  A `terraform destroy` command is first run with `-target=module.eks.aws_eks_node_group.this` to specifically destroy only the node group.
2.  A second `terraform destroy` command is then run to destroy all remaining resources in the environment.

This ensures the correct deletion order and prevents the race condition within the AWS API, allowing the EKS cluster and all its dependencies to be destroyed cleanly.