### PR TITLE
fix(destroy): Add sleep delay to EKS destroy process

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -51,6 +51,9 @@ jobs:
         run: terraform destroy -target=module.eks.aws_eks_node_group.this -var-file="${{ github.event.inputs.environment }}.tfvars" -auto-approve
         working-directory: terraform/environments/${{ github.event.inputs.environment }}
 
+      - name: Wait for Node Group to Detach
+        run: echo "Waiting for 60 seconds for AWS to detach node group..." && sleep 60
+
       - name: Terraform Destroy Remaining Resources
         run: terraform destroy -var-file="${{ github.event.inputs.environment }}.tfvars" -auto-approve
         working-directory: terraform/environments/${{ github.event.inputs.environment }}


### PR DESCRIPTION
This commit attempts to fix a persistent 'ResourceInUseException' error during EKS cluster destruction. The previous fix of using a targeted destroy was not sufficient, indicating a race condition where AWS requires more time to detach node groups before a cluster can be deleted.

A 60-second `sleep` delay has been added to the `destroy.yml` workflow between the node group destruction step and the final destruction step. This explicit wait should give the AWS control plane enough time to process the node group detachment, preventing the race condition and allowing the cluster to be destroyed cleanly.