### PR TITLE
refactor(tf): Fix EKS dynamic provider configuration

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,3 +1,16 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.0"
+    }
+  }
+}
+
 provider "aws" {
   region = var.aws_region
 }
@@ -38,4 +51,36 @@ module "dynamodb" {
   source = "../../modules/dynamodb"
 
   table_name = var.dynamodb_table_name
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = module.eks.cluster_ca_certificate
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+resource "kubernetes_config_map_v1" "aws_auth" {
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+
+  data = {
+    mapRoles = yamlencode([
+      {
+        rolearn  = module.eks.node_role_arn
+        username = "system:node:{{EC2PrivateDNSName}}"
+        groups   = [
+          "system:bootstrappers",
+          "system:nodes",
+        ]
+      },
+    ])
+  }
+
+  depends_on = [module.eks]
 }

--- a/terraform/environments/feature/main.tf
+++ b/terraform/environments/feature/main.tf
@@ -1,3 +1,16 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.0.0"
+    }
+  }
+}
+
 provider "aws" {
   region = var.aws_region
 }
@@ -38,4 +51,36 @@ module "dynamodb" {
   source = "../../modules/dynamodb"
 
   table_name = var.dynamodb_table_name
+}
+
+data "aws_eks_cluster_auth" "this" {
+  name = module.eks.cluster_name
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = module.eks.cluster_ca_certificate
+  token                  = data.aws_eks_cluster_auth.this.token
+}
+
+resource "kubernetes_config_map_v1" "aws_auth" {
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+
+  data = {
+    mapRoles = yamlencode([
+      {
+        rolearn  = module.eks.node_role_arn
+        username = "system:node:{{EC2PrivateDNSName}}"
+        groups   = [
+          "system:bootstrappers",
+          "system:nodes",
+        ]
+      },
+    ])
+  }
+
+  depends_on = [module.eks]
 }

--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -1,12 +1,3 @@
-terraform {
-  required_providers {
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.0.0"
-    }
-  }
-}
-
 # IAM Role for EKS Cluster
 resource "aws_iam_role" "cluster" {
   name = "${var.cluster_name}-cluster-role"
@@ -94,36 +85,4 @@ resource "aws_eks_node_group" "this" {
     aws_iam_role_policy_attachment.nodes_AmazonEKSWorkerNodePolicy,
     aws_iam_role_policy_attachment.nodes_AmazonEC2ContainerRegistryReadOnly,
   ]
-}
-
-data "aws_eks_cluster_auth" "this" {
-  name = aws_eks_cluster.this.name
-}
-
-provider "kubernetes" {
-  host                   = aws_eks_cluster.this.endpoint
-  cluster_ca_certificate = base64decode(aws_eks_cluster.this.certificate_authority[0].data)
-  token                  = data.aws_eks_cluster_auth.this.token
-}
-
-resource "kubernetes_config_map_v1" "aws_auth" {
-  metadata {
-    name      = "aws-auth"
-    namespace = "kube-system"
-  }
-
-  data = {
-    mapRoles = yamlencode([
-      {
-        rolearn  = aws_iam_role.nodes.arn
-        username = "system:node:{{EC2PrivateDNSName}}"
-        groups   = [
-          "system:bootstrappers",
-          "system:nodes",
-        ]
-      },
-    ])
-  }
-
-  depends_on = [aws_eks_node_group.this]
 }

--- a/terraform/modules/eks/outputs.tf
+++ b/terraform/modules/eks/outputs.tf
@@ -12,3 +12,8 @@ output "cluster_ca_certificate" {
   description = "Certificate authority data for the EKS cluster"
   value       = aws_eks_cluster.this.certificate_authority[0].data
 }
+
+output "node_role_arn" {
+  description = "ARN of the IAM role for the EKS nodes"
+  value       = aws_iam_role.nodes.arn
+}


### PR DESCRIPTION
This commit fixes a critical `Error: Invalid provider configuration` that occurred during `terraform import` and `destroy` operations.

The root cause was that the `kubernetes` provider was configured inside the EKS module, using outputs from the EKS cluster resource that was being created in the same module. This created a dependency paradox that Terraform could not resolve, especially during import and destroy plans.

This has been fixed by refactoring the Terraform configuration to follow best practices for managing resources with dynamic providers:

1.  The `kubernetes_config_map_v1` resource for `aws-auth` has been moved out of the EKS module.
2.  The `provider "kubernetes"` block has also been moved out of the module.
3.  The EKS module now provides the necessary `node_role_arn` as an output.
4.  The `aws-auth` ConfigMap and the `kubernetes` provider are now defined at the environment level (`dev/main.tf` and `feature/main.tf`), where they can be correctly configured using the outputs from the EKS module.

This change properly separates the creation of the cluster from the configuration of Kubernetes resources within it, resolving the dependency error and making the entire Terraform setup more robust and maintainable.