### PR TITLE
fix(cicd): Specify download path for plan artifact

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -111,6 +111,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: tfplan-${{ github.event.inputs.environment }}
+          path: terraform/environments/${{ github.event.inputs.environment }}
       - name: Terraform Apply
         id: tf-apply
         run: |


### PR DESCRIPTION
This commit fixes a 'no such file or directory' error for the `tfplan` file in the `apply_infra` job.

The error occurred because the `download-artifact` step was downloading the plan file to the workspace root, while the `terraform apply` step was being executed from within the environment's working directory (`terraform/environments/...`) and could not find it.

The fix adds the `path` input to the `download-artifact` step, instructing it to download the `tfplan` file directly into the correct working directory where the `apply` command is run. This ensures the plan file is found and the apply can proceed as intended.