### PR TITLE
fix(cicd): Pass entire Terraform working directory as artifact

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -77,11 +77,11 @@ jobs:
       - name: Terraform Plan
         run: terraform plan -var-file="${{ github.event.inputs.environment }}.tfvars" -out=tfplan
         working-directory: terraform/environments/${{ github.event.inputs.environment }}
-      - name: Upload Terraform Plan
+      - name: Upload Terraform Working Directory
         uses: actions/upload-artifact@v4
         with:
-          name: tfplan-${{ github.event.inputs.environment }}
-          path: terraform/environments/${{ github.event.inputs.environment }}/tfplan
+          name: tf-working-dir-${{ github.event.inputs.environment }}
+          path: terraform/environments/${{ github.event.inputs.environment }}
           retention-days: 1
 
   apply_infra:
@@ -107,10 +107,10 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
-      - name: Download Terraform Plan
+      - name: Download Terraform Working Directory
         uses: actions/download-artifact@v4
         with:
-          name: tfplan-${{ github.event.inputs.environment }}
+          name: tf-working-dir-${{ github.event.inputs.environment }}
           path: terraform/environments/${{ github.event.inputs.environment }}
       - name: Terraform Apply
         id: tf-apply


### PR DESCRIPTION
This commit fixes an 'Inconsistent dependency lock file' error that occurred during the `terraform apply` step of the infrastructure workflow.

The error was caused by only passing the `tfplan` file as an artifact from the `plan` job to the `apply` job. This meant the `.terraform.lock.hcl` file was not preserved, leading Terraform to detect an inconsistency for safety reasons.

The fix modifies the `infrastructure.yml` workflow to upload and download the entire Terraform working directory (`terraform/environments/<env>`) as the artifact. This ensures that the `.tf` files, `.tfvars` file, `.terraform` directory, and `.terraform.lock.hcl` file are all identical between the plan and apply stages, resolving the error and making the plan/apply separation robust.