### PR TITLE
fix(cicd): Correct artifact download path and add AGENTS.md

### DIFF
--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -70,11 +70,13 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
+      - name: Create Terraform Directory
+        run: mkdir -p terraform/environments/${{ github.event.inputs.environment }}
       - name: Download Terraform Destroy Plan
         uses: actions/download-artifact@v4
         with:
           name: tf-destroy-working-dir-${{ github.event.inputs.environment }}
-          path: .
+          path: terraform/environments/${{ github.event.inputs.environment }}
       - name: Terraform Apply Destroy
         run: terraform apply -auto-approve tfdestroyplan
         working-directory: terraform/environments/${{ github.event.inputs.environment }}

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -105,11 +105,13 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
+      - name: Create Terraform Directory
+        run: mkdir -p terraform/environments/${{ github.event.inputs.environment }}
       - name: Download Terraform Working Directory
         uses: actions/download-artifact@v4
         with:
           name: tf-working-dir-${{ github.event.inputs.environment }}
-          path: .
+          path: terraform/environments/${{ github.event.inputs.environment }}
       - name: Terraform Apply
         id: tf-apply
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# Agent Instructions
+
+This document provides instructions for AI agents working on this repository.
+
+## CI/CD Architecture
+
+The CI/CD process is split into two main workflows:
+
+1.  **`.github/workflows/infrastructure.yml`**: This workflow is for provisioning and managing all cloud infrastructure using Terraform.
+    -   It is triggered **manually** via the "Actions" tab in GitHub.
+    -   It requires selecting an environment (`dev` or `feature`).
+    -   It has a `plan` job and an `apply` job. The `apply` job requires manual approval if configured in GitHub's environment settings.
+    -   It calls the `application.yml` workflow upon successful completion.
+
+2.  **`.github/workflows/application.yml`**: This workflow handles the application build, test, scan, and deployment.
+    -   It is a **reusable workflow** and should not be run directly.
+    -   It is triggered automatically by the `infrastructure.yml` workflow.
+
+## Scripts
+
+All complex shell logic is externalized into the `scripts/` directory. When modifying workflow logic, check if an existing script should be updated.
+
+-   `scripts/backend_setup.sh`: Idempotent script to create/import the Terraform backend.
+-   `scripts/auto_import.sh`: Idempotent script to import existing AWS resources into the Terraform state for a given environment.
+-   `scripts/destroy_backend.sh`: Script to forcefully destroy the Terraform backend resources.
+
+## Terraform
+
+-   Infrastructure is defined in the `terraform/` directory.
+-   The `modules/` directory contains reusable components.
+-   The `environments/` directory contains the top-level configurations for each environment (`dev`, `feature`).
+-   The `kubernetes_config/` directory contains the standalone configuration for the `aws-auth` ConfigMap.


### PR DESCRIPTION
I've put together the final set of fixes to resolve the workflow errors and have added the AGENTS.md file as you requested.

Here's a breakdown of the changes:

**Fixes:**

1.  **Correct Artifact Download Path:** I fixed a 'No such file or directory' error in the `apply_infra` and `apply-destroy` jobs. The problem was that after removing the `actions/checkout` step, the directory structure wasn't being created before the artifact download. I've corrected this by adding a `mkdir -p` step and specifying the correct download `path`.

**New Additions:**

1.  **`AGENTS.md`:** I've added an `AGENTS.md` file to the root of the repository. It contains a detailed description of the new CI/CD architecture, the purpose of the externalized scripts, and the Terraform project structure. This will serve as a guide for any future work on the project.

This concludes the extensive refactoring and bug fixing I've been working on.