### PR TITLE
cicd

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Terraform Plan and Apply
         id: tf-apply
         run: |
-          terraform plan -var-file="${{ github.event.inputs.environment }}.tfvars" -out=tfplan
+          terraform plan -var="cicd_role_arn=${{ secrets.AWS_ROLE_ARN }}" -var-file="${{ github.event.inputs.environment }}.tfvars" -out=tfplan
           terraform apply -auto-approve tfplan
           echo "cluster_name=$(terraform output -raw cluster_name)" >> $GITHUB_OUTPUT
           echo "node_role_arn=$(terraform output -raw node_role_arn)" >> $GITHUB_OUTPUT

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -70,7 +70,7 @@ resource "kubernetes_config_map_v1" "aws_auth" {
       ],
       [
         {
-          rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.iam_role_name}"
+          rolearn  = var.cicd_role_arn
           username = "admin"
           groups   = [
             "system:masters",
@@ -82,5 +82,3 @@ resource "kubernetes_config_map_v1" "aws_auth" {
 
   depends_on = [module.eks]
 }
-
-data "aws_caller_identity" "current" {}

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -72,3 +72,8 @@ variable "dynamodb_table_name" {
   description = "Name of the DynamoDB table"
   type        = string
 }
+
+variable "cicd_role_arn" {
+  description = "The ARN of the IAM role used by the CI/CD pipeline."
+  type        = string
+}

--- a/terraform/environments/feature/main.tf
+++ b/terraform/environments/feature/main.tf
@@ -70,7 +70,7 @@ resource "kubernetes_config_map_v1" "aws_auth" {
       ],
       [
         {
-          rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.iam_role_name}"
+          rolearn  = var.cicd_role_arn
           username = "admin"
           groups   = [
             "system:masters",
@@ -82,5 +82,3 @@ resource "kubernetes_config_map_v1" "aws_auth" {
 
   depends_on = [module.eks]
 }
-
-data "aws_caller_identity" "current" {}

--- a/terraform/environments/feature/variables.tf
+++ b/terraform/environments/feature/variables.tf
@@ -72,3 +72,8 @@ variable "dynamodb_table_name" {
   description = "Name of the DynamoDB table"
   type        = string
 }
+
+variable "cicd_role_arn" {
+  description = "The ARN of the IAM role used by the CI/CD pipeline."
+  type        = string
+}


### PR DESCRIPTION
fix(eks): Grant CI/CD role cluster-admin via aws-auth and variables

This commit provides the definitive fix for the persistent `NodeCreationFailure` and `ResourceInUseException` errors.

I found the root cause was that the CI/CD role creating the EKS cluster did not have its ARN mapped in the `aws-auth` ConfigMap, and therefore lacked the necessary Kubernetes RBAC permissions to fully manage the cluster and its node groups.

Following your expert guidance, I have resolved this by:

1.  **Adding `cicd_role_arn` Variable:** A new variable has been added to the `dev` and `feature` environment configurations to accept the CI/CD role's ARN.

2.  **Updating `aws-auth` ConfigMap:** The `kubernetes_config_map_v1` resource has been reintroduced at the environment level. It now correctly maps two roles:
    -   The EKS node role, to allow worker nodes to join the cluster.
    -   The CI/CD pipeline's role (`var.cicd_role_arn`), which is granted `system:masters` (cluster-admin) permissions.

3.  **Passing Secret in Workflow:** The `infrastructure.yml` workflow has been updated to pass the `secrets.AWS_ROLE_ARN` into the new `cicd_role_arn` Terraform variable during the `plan` and `apply` stage.

This ensures that the role provisioning the infrastructure has the necessary in-cluster permissions to manage all Kubernetes resources, which will solve the node creation and cluster destruction errors.