### PR TITLE
fix(cicd): Restore auto-import script for idempotency

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -77,13 +77,16 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
-      - name: Terraform Init
-        run: |
-          terraform init \
-            -backend-config="bucket=${{ needs.provision_backend.outputs.s3_bucket_name }}" \
-            -backend-config="key=${{ github.event.inputs.environment }}/terraform.tfstate" \
-            -backend-config="region=${{ secrets.AWS_REGION }}" \
-            -backend-config="dynamodb_table=${{ needs.provision_backend.outputs.dynamodb_table_name }}"
+      - name: Make auto_import.sh executable
+        run: chmod +x ${{ github.workspace }}/scripts/auto_import.sh
+      - name: Run Auto-Import Script and Terraform Init
+        run: ${{ github.workspace }}/scripts/auto_import.sh
+        env:
+          ENVIRONMENT: ${{ github.event.inputs.environment }}
+          BUCKET: ${{ needs.provision_backend.outputs.s3_bucket_name }}
+          KEY: "${{ github.event.inputs.environment }}/terraform.tfstate"
+          REGION: ${{ secrets.AWS_REGION }}
+          DYNAMO_TABLE: ${{ needs.provision_backend.outputs.dynamodb_table_name }}
         working-directory: terraform/environments/${{ github.event.inputs.environment }}
       - name: Terraform Plan and Apply
         id: tf-apply

--- a/scripts/auto_import.sh
+++ b/scripts/auto_import.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+set -e
+
+# This script initializes Terraform for a specific environment and imports existing
+# resources to prevent errors.
+
+# These variables are expected to be passed from the GitHub workflow.
+# E.g., ENVIRONMENT, BUCKET, KEY, REGION, DYNAMO_TABLE
+if [[ -z "$ENVIRONMENT" || -z "$BUCKET" || -z "$KEY" || -z "$REGION" || -z "$DYNAMO_TABLE" ]]; then
+  echo "Error: One or more required environment variables are not set."
+  exit 1
+fi
+
+echo "--- Initializing Terraform for $ENVIRONMENT environment ---"
+terraform init \
+  -backend-config="bucket=$BUCKET" \
+  -backend-config="key=$KEY" \
+  -backend-config="region=$REGION" \
+  -backend-config="dynamodb_table=$DYNAMO_TABLE"
+
+echo "--- Checking for existing resources to import into $ENVIRONMENT ---"
+
+# Extract names from tfvars file
+EKS_CLUSTER_NAME=$(grep "cluster_name" "${ENVIRONMENT}.tfvars" | awk -F'=' '{print $2}' | tr -d ' "')
+ECR_REPO_NAME=$(grep "ecr_repository_name" "${ENVIRONMENT}.tfvars" | awk -F'=' '{print $2}' | tr -d ' "')
+DYNAMO_TABLE_NAME=$(grep "dynamodb_table_name" "${ENVIRONMENT}.tfvars" | awk -F'=' '{print $2}' | tr -d ' "')
+
+# Check and import IAM Roles
+CLUSTER_ROLE_NAME="${EKS_CLUSTER_NAME}-cluster-role"
+NODE_ROLE_NAME="${EKS_CLUSTER_NAME}-node-role"
+
+if aws iam get-role --role-name "$CLUSTER_ROLE_NAME" >/dev/null 2>&1; then
+  echo "IAM role '$CLUSTER_ROLE_NAME' exists."
+  if ! (terraform state list 2>/dev/null || true) | grep -q 'module.eks.aws_iam_role.cluster'; then
+    echo "Importing EKS cluster IAM role..."
+    terraform import -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_iam_role.cluster "$CLUSTER_ROLE_NAME"
+  fi
+else
+  echo "IAM role '$CLUSTER_ROLE_NAME' does not exist."
+fi
+
+if aws iam get-role --role-name "$NODE_ROLE_NAME" >/dev/null 2>&1; then
+  echo "IAM role '$NODE_ROLE_NAME' exists."
+  if ! (terraform state list 2>/dev/null || true) | grep -q 'module.eks.aws_iam_role.nodes'; then
+    echo "Importing EKS node IAM role..."
+    terraform import -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_iam_role.nodes "$NODE_ROLE_NAME"
+  fi
+else
+  echo "IAM role '$NODE_ROLE_NAME' does not exist."
+fi
+
+# Check and import EKS Cluster
+if aws eks describe-cluster --name "$EKS_CLUSTER_NAME" >/dev/null 2>&1; then
+  echo "EKS cluster '$EKS_CLUSTER_NAME' exists."
+  if ! (terraform state list 2>/dev/null || true) | grep -q 'module.eks.aws_eks_cluster.this'; then
+    echo "Importing EKS cluster..."
+    terraform import -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_eks_cluster.this "$EKS_CLUSTER_NAME"
+  else
+    echo "EKS cluster already in state."
+  fi
+else
+  echo "EKS cluster '$EKS_CLUSTER_NAME' does not exist. Skipping import."
+fi
+
+# Check and import EKS Node Group
+NODE_GROUP_NAME="${EKS_CLUSTER_NAME}-node-group"
+if aws eks describe-nodegroup --cluster-name "$EKS_CLUSTER_NAME" --nodegroup-name "$NODE_GROUP_NAME" >/dev/null 2>&1; then
+  echo "EKS node group '$NODE_GROUP_NAME' exists."
+  if ! (terraform state list 2>/dev/null || true) | grep -q 'module.eks.aws_eks_node_group.this'; then
+    echo "Importing EKS node group..."
+    terraform import -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_eks_node_group.this "${EKS_CLUSTER_NAME}:${NODE_GROUP_NAME}"
+  else
+    echo "EKS node group already in state."
+  fi
+else
+  echo "EKS node group '$NODE_GROUP_NAME' does not exist. Skipping import."
+fi
+
+# Check and import ECR Repository
+if aws ecr describe-repositories --repository-names "$ECR_REPO_NAME" >/dev/null 2>&1; then
+  echo "ECR repository '$ECR_REPO_NAME' exists."
+  if ! (terraform state list 2>/dev/null || true) | grep -q 'module.ecr.aws_ecr_repository.app'; then
+    echo "Importing ECR repository..."
+    terraform import -var-file="${ENVIRONMENT}.tfvars" module.ecr.aws_ecr_repository.app "$ECR_REPO_NAME"
+  else
+    echo "ECR repository already in state."
+  fi
+else
+  echo "ECR repository '$ECR_REPO_NAME' does not exist. Skipping import."
+fi
+
+# Check and import App's DynamoDB Table
+if aws dynamodb describe-table --table-name "$DYNAMO_TABLE_NAME" >/dev/null 2>&1; then
+  echo "App DynamoDB table '$DYNAMO_TABLE_NAME' exists."
+  if ! (terraform state list 2>/dev/null || true) | grep -q 'module.dynamodb.aws_dynamodb_table.app_table'; then
+    echo "Importing App DynamoDB table..."
+    terraform import -var-file="${ENVIRONMENT}.tfvars" module.dynamodb.aws_dynamodb_table.app_table "$DYNAMO_TABLE_NAME"
+  else
+    echo "App DynamoDB table already in state."
+  fi
+else
+  echo "App DynamoDB table '$DYNAMO_TABLE_NAME' does not exist. Skipping import."
+fi


### PR DESCRIPTION
I have re-introduced the `auto_import.sh` script into the `infrastructure.yml` workflow.

This script was mistakenly removed in a previous refactoring. It is essential for making the infrastructure pipeline idempotent, meaning it can recover gracefully from previous failed runs. The script checks for the existence of key resources (IAM Roles, EKS Cluster, ECR Repo, etc.) before running `terraform plan` and `apply`, and imports them into the state if they exist.

This will resolve the `RepositoryAlreadyExistsException`, `EntityAlreadyExists`, and `ResourceInUseException` errors you reported.

The `VpcLimitExceeded` error is an AWS account limit, and you will need to resolve it by deleting an unused VPC in your account.