### PR TITLE
fix(cicd): Pass CI/CD role ARN to import script

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -87,6 +87,7 @@ jobs:
           KEY: "${{ github.event.inputs.environment }}/terraform.tfstate"
           REGION: ${{ secrets.AWS_REGION }}
           DYNAMO_TABLE: ${{ needs.provision_backend.outputs.dynamodb_table_name }}
+          CICD_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
         working-directory: terraform/environments/${{ github.event.inputs.environment }}
       - name: Terraform Plan and Apply
         id: tf-apply

--- a/scripts/auto_import.sh
+++ b/scripts/auto_import.sh
@@ -33,7 +33,7 @@ if aws iam get-role --role-name "$CLUSTER_ROLE_NAME" >/dev/null 2>&1; then
   echo "IAM role '$CLUSTER_ROLE_NAME' exists."
   if ! (terraform state list 2>/dev/null || true) | grep -q 'module.eks.aws_iam_role.cluster'; then
     echo "Importing EKS cluster IAM role..."
-    terraform import -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_iam_role.cluster "$CLUSTER_ROLE_NAME"
+    terraform import -var="cicd_role_arn=${CICD_ROLE_ARN}" -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_iam_role.cluster "$CLUSTER_ROLE_NAME"
   fi
 else
   echo "IAM role '$CLUSTER_ROLE_NAME' does not exist."
@@ -43,7 +43,7 @@ if aws iam get-role --role-name "$NODE_ROLE_NAME" >/dev/null 2>&1; then
   echo "IAM role '$NODE_ROLE_NAME' exists."
   if ! (terraform state list 2>/dev/null || true) | grep -q 'module.eks.aws_iam_role.nodes'; then
     echo "Importing EKS node IAM role..."
-    terraform import -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_iam_role.nodes "$NODE_ROLE_NAME"
+    terraform import -var="cicd_role_arn=${CICD_ROLE_ARN}" -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_iam_role.nodes "$NODE_ROLE_NAME"
   fi
 else
   echo "IAM role '$NODE_ROLE_NAME' does not exist."
@@ -54,7 +54,7 @@ if aws eks describe-cluster --name "$EKS_CLUSTER_NAME" >/dev/null 2>&1; then
   echo "EKS cluster '$EKS_CLUSTER_NAME' exists."
   if ! (terraform state list 2>/dev/null || true) | grep -q 'module.eks.aws_eks_cluster.this'; then
     echo "Importing EKS cluster..."
-    terraform import -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_eks_cluster.this "$EKS_CLUSTER_NAME"
+    terraform import -var="cicd_role_arn=${CICD_ROLE_ARN}" -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_eks_cluster.this "$EKS_CLUSTER_NAME"
   else
     echo "EKS cluster already in state."
   fi
@@ -68,7 +68,7 @@ if aws eks describe-nodegroup --cluster-name "$EKS_CLUSTER_NAME" --nodegroup-nam
   echo "EKS node group '$NODE_GROUP_NAME' exists."
   if ! (terraform state list 2>/dev/null || true) | grep -q 'module.eks.aws_eks_node_group.this'; then
     echo "Importing EKS node group..."
-    terraform import -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_eks_node_group.this "${EKS_CLUSTER_NAME}:${NODE_GROUP_NAME}"
+    terraform import -var="cicd_role_arn=${CICD_ROLE_ARN}" -var-file="${ENVIRONMENT}.tfvars" module.eks.aws_eks_node_group.this "${EKS_CLUSTER_NAME}:${NODE_GROUP_NAME}"
   else
     echo "EKS node group already in state."
   fi
@@ -81,7 +81,7 @@ if aws ecr describe-repositories --repository-names "$ECR_REPO_NAME" >/dev/null 
   echo "ECR repository '$ECR_REPO_NAME' exists."
   if ! (terraform state list 2>/dev/null || true) | grep -q 'module.ecr.aws_ecr_repository.app'; then
     echo "Importing ECR repository..."
-    terraform import -var-file="${ENVIRONMENT}.tfvars" module.ecr.aws_ecr_repository.app "$ECR_REPO_NAME"
+    terraform import -var="cicd_role_arn=${CICD_ROLE_ARN}" -var-file="${ENVIRONMENT}.tfvars" module.ecr.aws_ecr_repository.app "$ECR_REPO_NAME"
   else
     echo "ECR repository already in state."
   fi
@@ -94,7 +94,7 @@ if aws dynamodb describe-table --table-name "$DYNAMO_TABLE_NAME" >/dev/null 2>&1
   echo "App DynamoDB table '$DYNAMO_TABLE_NAME' exists."
   if ! (terraform state list 2>/dev/null || true) | grep -q 'module.dynamodb.aws_dynamodb_table.app_table'; then
     echo "Importing App DynamoDB table..."
-    terraform import -var-file="${ENVIRONMENT}.tfvars" module.dynamodb.aws_dynamodb_table.app_table "$DYNAMO_TABLE_NAME"
+    terraform import -var="cicd_role_arn=${CICD_ROLE_ARN}" -var-file="${ENVIRONMENT}.tfvars" module.dynamodb.aws_dynamodb_table.app_table "$DYNAMO_TABLE_NAME"
   else
     echo "App DynamoDB table already in state."
   fi


### PR DESCRIPTION
This commit resolves the final 'No value for required variable' error for `cicd_role_arn`.

The error occurred because the `auto_import.sh` script, which runs `terraform import`, was not being provided with the value for the newly added `cicd_role_arn` variable.

This has been fixed by:
1.  Updating `auto_import.sh` to use a `CICD_ROLE_ARN` environment variable when calling `terraform import`.
2.  Updating the `infrastructure.yml` workflow to pass the `secrets.AWS_ROLE_ARN` into the `CICD_ROLE_ARN` environment variable for the auto-import step.

This ensures that all terraform commands (`import`, `plan`, `apply`) receive all the necessary variables, finally resolving the full chain of dependency and variable errors.